### PR TITLE
Log: Switch to structured_logging

### DIFF
--- a/cmd/tapo/main.go
+++ b/cmd/tapo/main.go
@@ -82,9 +82,10 @@ func getPlug(cfg *cmdCfg, addr string) (*tapo.Plug, error) {
 	}
 
 	tapolog := kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
-	tapolog = kitlog.With(tapolog, "ip", addr)
+	tapolog = kitlog.With(tapolog, "ts", kitlog.DefaultTimestampUTC, "ip", addr)
 	if cfg.Debug {
 		tapolog = level.NewFilter(tapolog, level.AllowDebug()) // only normal log messages
+		tapolog = kitlog.With(tapolog, "caller", kitlog.DefaultCaller)
 	} else {
 		tapolog = level.NewFilter(tapolog) // only normal log messages
 	}

--- a/cmd/tapoweb/main.go
+++ b/cmd/tapoweb/main.go
@@ -355,15 +355,18 @@ func getAllDevices(username, password string) ([]Device, []netip.Addr, error) {
 			return nil, nil, fmt.Errorf("invalid IP '%s': %w", d.Result.IP.String(), err)
 		}
 		log.Printf("Getting info for '%s'", addr)
-		plug := tapo.NewPlug(addr, nil)
-		if err := plug.Handshake(username, password); err != nil {
-			log.Printf("Warning: handshake failed for %s: %v", addr, err)
+		plug, err := tapo.NewPlug(addr, username, password, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := plug.Handshake(); err != nil {
+			log.Printf("warning: handshake failed for %s: %v", addr, err)
 			failed = append(failed, addr)
 			continue
 		}
 		info, err := plug.GetDeviceInfo()
 		if err != nil {
-			log.Printf("Warning: GetDeviceInfo failed for %s: %v", addr, err)
+			log.Printf("warning: GetDeviceInfo failed for %s: %v", addr, err)
 			failed = append(failed, addr)
 			continue
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,16 @@
 module github.com/insomniacslk/tapo
 
-go 1.21
+go 1.21.1
+
+toolchain go1.21.3
 
 require (
+	github.com/go-kit/log v0.2.1
 	github.com/google/uuid v1.3.1
 	github.com/insomniacslk/xjson v0.0.0-20231023101448-2249e546a131
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/mergermarket/go-pkcs7 v0.0.0-20170926155232-153b18ea13c9
 	github.com/spf13/pflag v1.0.5
 )
+
+require github.com/go-logfmt/logfmt v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
+github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/insomniacslk/xjson v0.0.0-20231023101448-2249e546a131 h1:bVGPuMhjgFtxVdQGfYnFq+EnCqArOAjLNciow/nArwE=

--- a/plug.go
+++ b/plug.go
@@ -60,8 +60,8 @@ func NewPlug(addr netip.Addr, user, password string, tapolog log.Logger) (*Plug,
 	var logger log.Logger
 	if tapolog == nil {
 		logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-		logger = log.With(logger, "ts", log.DefaultTimestampUTC)
-		logger = log.With(logger, "ip", addr)
+		logger = log.With(logger, "ts", log.DefaultTimestampUTC, "ip", addr)
+		logger = log.With(logger)
 		logger = level.NewFilter(logger) // only normal log messages
 	} else {
 		logger = tapolog

--- a/session.go
+++ b/session.go
@@ -5,7 +5,7 @@ package tapo
 import "net/netip"
 
 type Session interface {
-	Handshake(addr netip.Addr, username, password string) error
+	Handshake() error
 	Request([]byte) ([]byte, error)
 	Addr() netip.Addr
 }


### PR DESCRIPTION
Switch logging to structured logging (refer to github.com/go-kit/log).
Enable clients to modify logging behaviour.
Some parameter consolidation.

This PR is outcome of our discussions in https://github.com/evcc-io/evcc/pull/10606