### PR TITLE
Reauthenticate on connection error

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -42,7 +42,7 @@ type DiscoverResponse struct {
 			HTTPPort       int    `json:"http_port"`
 			Lv             int    `json:"lv"`
 		} `json:"mgt_encrypt_schm"`
-		ErrorCode int `json:"error_code"`
+		ErrorCode TapoStatus `json:"error_code"`
 	} `json:"result"`
 }
 
@@ -69,9 +69,18 @@ type HandshakeRequest struct {
 	} `json:"params"`
 }
 
+type UntypedResponse struct {
+	ResponseEnvelope
+	Result *json.RawMessage `json:"result,omitempty"`
+}
+
+type ResponseEnvelope struct {
+	ErrorCode TapoStatus `json:"error_code"`
+}
+
 type HandshakeResponse struct {
-	ErrorCode TapoError `json:"error_code"`
-	Result    struct {
+	ResponseEnvelope
+	Result struct {
 		Key string `json:"key"`
 	}
 }
@@ -96,8 +105,8 @@ type LoginDeviceRequest struct {
 }
 
 type LoginDeviceResponse struct {
-	ErrorCode TapoError `json:"error_code"`
-	Result    struct {
+	ResponseEnvelope
+	Result struct {
 		Token string `json:"token"`
 	} `json:"result"`
 }
@@ -166,8 +175,8 @@ type DeviceInfo struct {
 }
 
 type GetDeviceInfoResponse struct {
-	ErrorCode TapoError  `json:"error_code"`
-	Result    DeviceInfo `json:"result"`
+	ResponseEnvelope
+	Result DeviceInfo `json:"result"`
 }
 
 func NewGetDeviceInfoRequest() *GetDeviceInfoRequest {
@@ -185,8 +194,8 @@ type SetDeviceInfoRequest struct {
 }
 
 type SetDeviceInfoResponse struct {
-	ErrorCode TapoError `json:"error_code"`
-	Result    struct {
+	ResponseEnvelope
+	Result struct {
 		Response string `json:"response"`
 	}
 }
@@ -233,8 +242,8 @@ type EnergyUsage struct {
 }
 
 type GetDeviceUsageResponse struct {
-	ErrorCode TapoError   `json:"error_code"`
-	Result    DeviceUsage `json:"result"`
+	ResponseEnvelope
+	Result DeviceUsage `json:"result"`
 }
 
 func NewGetDeviceUsageRequest() *GetDeviceUsageRequest {
@@ -250,8 +259,8 @@ type GetEnergyUsageRequest struct {
 }
 
 type GetEnergyUsageResponse struct {
-	ErrorCode TapoError   `json:"error_code"`
-	Result    EnergyUsage `json:"result"`
+	ResponseEnvelope
+	Result EnergyUsage `json:"result"`
 }
 
 func NewGetEnergyUsageRequest() *GetEnergyUsageRequest {
@@ -269,8 +278,8 @@ type SecurePassthroughRequest struct {
 }
 
 type SecurePassthroughResponse struct {
-	ErrorCode TapoError `json:"error_code"`
-	Result    struct {
+	ResponseEnvelope
+	Result struct {
 		Response string `json:"response"`
 	}
 }

--- a/session.go
+++ b/session.go
@@ -6,6 +6,6 @@ import "net/netip"
 
 type Session interface {
 	Handshake(addr netip.Addr, username, password string) error
-	Request([]byte) ([]byte, error)
+	Request([]byte) (*UntypedResponse, error)
 	Addr() netip.Addr
 }


### PR DESCRIPTION
As reported in https://github.com/evcc-io/evcc/issues/25247 , there are cases where a session becomes invalid and a handshake should be tried again to refresh the credentials. This should also help with long-running sessions as reported in
https://github.com/evcc-io/evcc/discussions/13604 .

To refresh credentials I had to make a few extra changes as well:
* parse the Tapo response in the Tapo.Request flow, to check for application errors, which introduces a breaking change in the `Session` interface
* introduce `TapoStatus` and related variables for Tapo status/error codes
* reorganize Tapo responses using a common `ResponseEnvelope`